### PR TITLE
Add support for building with gcc

### DIFF
--- a/Drivers/BSP/Components/gps/gps.c
+++ b/Drivers/BSP/Components/gps/gps.c
@@ -1,4 +1,4 @@
-#include "GPS.h"  
+#include "gps.h"
 #include "at.h"  
 #include "vcom.h"
 #include "delay.h"

--- a/Drivers/BSP/Components/gps/gps.c
+++ b/Drivers/BSP/Components/gps/gps.c
@@ -1,3 +1,4 @@
+#include <ctype.h>
 #include "gps.h"
 #include "at.h"  
 #include "vcom.h"

--- a/Drivers/BSP/Components/iwdg/iwdg.h
+++ b/Drivers/BSP/Components/iwdg/iwdg.h
@@ -79,7 +79,7 @@ Maintainer: Miguel Luis and Gregory Cristian
  * @retval None
  */
 void iwdg_init(void);
-uint32_t GetLSIFrequency(void);
+static uint32_t GetLSIFrequency(void);
 void TIMER_IRQHandler(void);
 void IWDG_Refresh(void);
 	 

--- a/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/gcc/Makefile
+++ b/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/gcc/Makefile
@@ -1,0 +1,201 @@
+# GNU Makefile for building DRAGINO-LRWAN (AT) firmware with GCC ARM toolchain
+#
+# Copyright 2021 Tormod Volden
+
+NAME = lgt92
+
+REGION = EU868
+
+BUILDDIR = build
+
+DRIVERS_BSP_COMPONENTS = \
+        flash_eraseprogram.c \
+        iwdg.c \
+        sx1276.c \
+        gpio_exti.c \
+        filter.c \
+        IIC.c \
+        gps.c \
+        mpu9250.c \
+        bsp_usart2.c
+DRIVERS_BSP_STM32L0xx_NUCLEO = \
+        stm32l0xx_nucleo.c
+DRIVERS_BSP_SX1276MB1LAS = \
+        sx1276mb1las.c
+DRIVERS_CMSIS = \
+        system_stm32l0xx.c
+DRIVERS_STM32L0xx_HAL_DRIVER = \
+        stm32l0xx_hal_spi.c \
+        stm32l0xx_hal_uart.c \
+        stm32l0xx_hal_adc.c \
+        stm32l0xx_hal_rcc.c \
+        stm32l0xx_hal_rcc_ex.c \
+        stm32l0xx_hal.c \
+        stm32l0xx_hal_cortex.c \
+        stm32l0xx_hal_gpio.c \
+        stm32l0xx_hal_dma.c \
+        stm32l0xx_hal_pwr.c \
+        stm32l0xx_hal_pwr_ex.c \
+        stm32l0xx_hal_rtc.c \
+        stm32l0xx_hal_rtc_ex.c \
+        stm32l0xx_hal_tim.c \
+        stm32l0xx_hal_tim_ex.c \
+        stm32l0xx_hal_adc_ex.c \
+        stm32l0xx_hal_uart_ex.c \
+        stm32l0xx_hal_i2c.c \
+        stm32l0xx_hal_i2c_ex.c \
+        stm32l0xx_hal_flash_ex.c \
+        stm32l0xx_hal_flash.c \
+        stm32l0xx_hal_iwdg.c
+MIDDLEWARES_LORA_MAC_REGION = \
+        Region.c \
+        RegionAS923.c \
+        RegionAU915.c \
+        RegionCN470.c \
+        RegionCN779.c \
+        RegionCommon.c \
+        RegionEU433.c \
+        RegionEU868.c \
+        RegionIN865.c \
+        RegionKR920.c \
+        RegionUS915.c \
+        RegionRU864.c \
+        RegionKZ865.c \
+        LoRaMac.c \
+        LoRaMacCrypto.c \
+        lora-test.c
+MIDDLEWARES_LORA_UTILITIES = \
+        delay.c \
+        low_power_manager.c \
+        timeServer.c \
+        utilities.c \
+        trace.c \
+        queue.c
+MIDDLEWARES_LORA_CRYPTO = \
+        aes.c \
+        cmac.c
+PROJECTS_END_NODE = \
+        bsp.c \
+        debug.c \
+        hw_gpio.c \
+        hw_rtc.c \
+        hw_spi.c \
+        main.c \
+        stm32l0xx_hal_msp.c \
+        stm32l0xx_hw.c \
+        stm32l0xx_it.c \
+        vcom.c \
+        at.c \
+        command.c \
+        lora.c \
+        tiny_sscanf.c \
+        tiny_vsnprintf.c
+PROJECTS_STARTUP = \
+        startup_stm32l072xx.s
+
+CSRC := \
+        $(DRIVERS_BSP_COMPONENTS) \
+        $(DRIVERS_BSP_STM32L0xx_NUCLEO) \
+        $(DRIVERS_BSP_SX1276MB1LAS) \
+        $(DRIVERS_CMSIS) \
+        $(DRIVERS_STM32L0xx_HAL_DRIVER) \
+        $(MIDDLEWARES_LORA_MAC_REGION) \
+        $(MIDDLEWARES_LORA_UTILITIES) \
+        $(MIDDLEWARES_LORA_CRYPTO) \
+        $(PROJECTS_END_NODE)
+
+ASRC := \
+        $(PROJECTS_STARTUP)
+
+OBJS := $(CSRC:%=$(BUILDDIR)/%.o) $(ASRC:%=$(BUILDDIR)/%.o)
+
+INCDIRS = \
+Drivers/BSP/STM32L0xx_Nucleo \
+Drivers/STM32L0xx_HAL_Driver/Inc \
+Drivers/CMSIS/Device/ST/STM32L0xx/Include \
+Drivers/CMSIS/Include \
+Drivers/BSP/Components/Common \
+Drivers/BSP/Components/sx1276 \
+Drivers/BSP/sx1276mb1las \
+Drivers/BSP/Components/flash_eraseprogram \
+Drivers/BSP/Components/gpio_exti \
+Drivers/BSP/Components/iwdg \
+Drivers/BSP/Components/filter \
+Drivers/BSP/Components/gps \
+Drivers/BSP/Components/mpu9250 \
+Drivers/BSP/Components/IIC \
+Drivers/BSP/Components/usart \
+Middlewares/Third_Party/Lora/Crypto \
+Middlewares/Third_Party/Lora/Mac \
+Middlewares/Third_Party/Lora/Phy \
+Middlewares/Third_Party/Lora/Utilities \
+Middlewares/Third_Party/Lora/Core
+
+CSRCDIRS = \
+        Drivers/CMSIS/Device/ST/STM32L0xx/Source/Templates \
+        Drivers/STM32L0xx_HAL_Driver/Src \
+        Middlewares/Third_Party/Lora/Mac/region \
+        $(INCDIRS)
+
+ASRCDIRS = \
+        Drivers/CMSIS/Device/ST/STM32L0xx/Source/Templates/gcc
+
+vpath %.c ../src $(addprefix ../../../../../../,$(CSRCDIRS))
+vpath %.s $(addprefix ../../../../../../,$(ASRCDIRS))
+INCFLAGS = -I../inc $(patsubst %,-I../../../../../../%,$(INCDIRS))
+
+# Toolchain setup
+CROSS_COMPILE = arm-none-eabi-
+CC = $(CROSS_COMPILE)gcc
+LD = $(CROSS_COMPILE)ld -v
+AR = $(CROSS_COMPILE)ar
+AS = $(CROSS_COMPILE)as
+CP = $(CROSS_COMPILE)objcopy
+OD = $(CROSS_COMPILE)objdump
+SZ = $(CROSS_COMPILE)size
+
+ARCHFLAGS += -mcpu=cortex-m0plus -mthumb
+ASFLAGS += $(ARCHFLAGS)
+CFLAGS += $(ARCHFLAGS) -Os
+LDFLAGS += $(ARCHFLAGS)
+
+CPPFLAGS += $(INCFLAGS)
+
+CFLAGS += -ffunction-sections
+LDFLAGS += -Wl,--gc-sections
+
+LDFLAGS += -T gcc-stm32l072cz.ld
+LDLIBS += -specs=nano.specs -specs=nosys.specs -lm
+
+CFLAGS += -DSTM32L072xx -DUSE_STM32L0XX_NUCLEO -DUSE_HAL_DRIVER -DUSE_SHT -DREGION_$(REGION)
+
+
+all: $(BUILDDIR)/$(NAME).hex
+
+$(BUILDDIR)/$(NAME).hex: $(BUILDDIR)/$(NAME).elf
+	$(CP) -O ihex $^ $@
+
+$(BUILDDIR)/$(NAME).elf: $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+$(BUILDDIR)/%.c.o: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+$(BUILDDIR)/%.s.o: %.s
+	$(AS) $(ASFLAGS) -c $< -o $@
+
+$(OBJS): | $(BUILDDIR)
+$(BUILDDIR):
+	mkdir $@
+
+size: $(BUILDDIR)/$(NAME).elf
+	$(SZ) --format=SysV --radix=16 $^ | egrep "^.text|^.data|^.bss"
+
+OPENOCD = openocd -f interface/stlink-v2.cfg -c "transport select hla_swd" \
+           -f target/stm32l0.cfg
+
+flash: $(BUILDDIR)/$(NAME).hex
+	$(OPENOCD) -c "program $< verify reset exit"
+
+clean:
+	rm -f $(OBJS) $(BUILDDIR)/$(NAME).hex $(BUILDDIR)/$(NAME).elf

--- a/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/gcc/gcc-stm32l072cz.ld
+++ b/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/gcc/gcc-stm32l072cz.ld
@@ -1,0 +1,192 @@
+/* Linker script to configure memory regions for STM32L072CZTx
+ */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 0x30000 /* 192K */
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x5000 /* 20K */
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.text :
+	{
+		KEEP(*(.isr_vector))
+		*(.text*)
+
+		KEEP(*(.init))
+		KEEP(*(.fini))
+
+		/* .ctors */
+		*crtbegin.o(.ctors)
+		*crtbegin?.o(.ctors)
+		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+		*(SORT(.ctors.*))
+		*(.ctors)
+
+		/* .dtors */
+		*crtbegin.o(.dtors)
+		*crtbegin?.o(.dtors)
+		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+		*(SORT(.dtors.*))
+		*(.dtors)
+
+		*(.rodata*)
+
+		KEEP(*(.eh_frame*))
+	} > FLASH
+
+	.ARM.extab :
+	{
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} > FLASH
+
+	__exidx_start = .;
+	.ARM.exidx :
+	{
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+	} > FLASH
+	__exidx_end = .;
+
+	/* To copy multiple ROM to RAM sections,
+	 * uncomment .copy.table section and,
+	 * define __STARTUP_COPY_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.copy.table :
+	{
+		. = ALIGN(4);
+		__copy_table_start__ = .;
+		LONG (__etext)
+		LONG (__data_start__)
+		LONG (__data_end__ - __data_start__)
+		LONG (__etext2)
+		LONG (__data2_start__)
+		LONG (__data2_end__ - __data2_start__)
+		__copy_table_end__ = .;
+	} > FLASH
+	*/
+
+	/* To clear multiple BSS sections,
+	 * uncomment .zero.table section and,
+	 * define __STARTUP_CLEAR_BSS_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.zero.table :
+	{
+		. = ALIGN(4);
+		__zero_table_start__ = .;
+		LONG (__bss_start__)
+		LONG (__bss_end__ - __bss_start__)
+		LONG (__bss2_start__)
+		LONG (__bss2_end__ - __bss2_start__)
+		__zero_table_end__ = .;
+	} > FLASH
+	*/
+
+	__etext = .;
+	_sidata = .; /* ST startup file syntax */
+
+	.data : AT (__etext)
+	{
+		__data_start__ = .;
+		_sdata = .; /* ST startup file syntax */
+		*(vtable)
+		*(.data*)
+
+		. = ALIGN(4);
+		/* preinit data */
+		PROVIDE_HIDDEN (__preinit_array_start = .);
+		KEEP(*(.preinit_array))
+		PROVIDE_HIDDEN (__preinit_array_end = .);
+
+		. = ALIGN(4);
+		/* init data */
+		PROVIDE_HIDDEN (__init_array_start = .);
+		KEEP(*(SORT(.init_array.*)))
+		KEEP(*(.init_array))
+		PROVIDE_HIDDEN (__init_array_end = .);
+
+
+		. = ALIGN(4);
+		/* finit data */
+		PROVIDE_HIDDEN (__fini_array_start = .);
+		KEEP(*(SORT(.fini_array.*)))
+		KEEP(*(.fini_array))
+		PROVIDE_HIDDEN (__fini_array_end = .);
+
+		KEEP(*(.jcr*))
+		. = ALIGN(4);
+		/* All data end */
+		__data_end__ = .;
+		_edata = .; /* ST startup file syntax */
+
+	} > RAM
+
+	.bss :
+	{
+		. = ALIGN(4);
+		__bss_start__ = .;
+		_sbss = .; /* ST startup file syntax */
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4);
+		__bss_end__ = .;
+		_ebss = .; /* ST startup file syntax */
+	} > RAM
+
+	.heap (COPY):
+	{
+		__end__ = .;
+		PROVIDE(end = .);
+		*(.heap*)
+		__HeapLimit = .;
+	} > RAM
+
+	/* .stack_dummy section doesn't contains any symbols. It is only
+	 * used for linker to calculate size of stack sections, and assign
+	 * values to stack symbols later */
+	.stack_dummy (COPY):
+	{
+		*(.stack*)
+	} > RAM
+
+	/* Set stack top to end of RAM, and stack limit move down by
+	 * size of stack_dummy section */
+	__StackTop = ORIGIN(RAM) + LENGTH(RAM);
+	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
+	PROVIDE(__stack = __StackTop);
+	_estack = __stack; /* ST startup file syntax */
+
+	/* Check if data + heap + stack exceeds RAM limit */
+	ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/src/lora.c
+++ b/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/src/lora.c
@@ -54,7 +54,7 @@
 #include "flash_eraseprogram.h"
 #include "version.h"
 #include "bsp.h"
-#include "GPS.h"
+#include "gps.h"
 #include "low_power_manager.h"
 #include "version.h"
 #include "mpu9250.h"

--- a/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/src/main.c
+++ b/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/src/main.c
@@ -58,7 +58,7 @@
 #include "gpio_exti.h"
 #include "iwdg.h"
 #include "delay.h"
-#include "GPS.h"  
+#include "gps.h"
 #include "bsp_usart2.h"
 #include "IIC.h"
 #include "mpu9250.h"

--- a/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/src/stm32l0xx_it.c
+++ b/Projects/Multi/Applications/LoRa/DRAGINO-LRWAN(AT)/src/stm32l0xx_it.c
@@ -63,7 +63,7 @@ Maintainer: Miguel Luis and Gregory Cristian
 #include "stm32l0xx_it.h"
 #include "vcom.h"
 #include "gpio_exti.h"
-#include "GPS.h"  
+#include "gps.h"
 #include "lora.h"
 #include "iwdg.h"
 


### PR DESCRIPTION
This makes the firmware build correctly with gcc.

Note that the resulting binary is currently larger, and will overlap with settings stored in flash. I will follow up with a way to move flash settings to a higher location in another merge request. Switching back and forth to the official firmware files will require a few extra steps. Eventually I hope the official firmware will also use a higher location for the flash settings.